### PR TITLE
Allow Roaming Source Network Address

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -379,6 +379,7 @@ pwm_password_policy_minimumlowercase: 0
 pwm_password_policy_minimumuppercase: 1
 pwm_password_policy_minimumunique: 5
 #pwm_guest_writeattributes: ''
+pwm_allow_roaming: true
 pwm_captcha_recaptcha_privatekey: '{{ pwm_captcha_recaptcha_privatekey_value }}'
 pwm_captcha_recaptcha_publickey: '{{ pwm_captcha_recaptcha_publickey_value }}'
 pwm_captcha_recaptcha_mode: V3

--- a/templates/PwmConfiguration.xml.j2
+++ b/templates/PwmConfiguration.xml.j2
@@ -281,6 +281,10 @@
       <default />
       {% endif %}
     </setting>
+    <setting key="network.allowMultiIPSession" syntax="BOOLEAN" syntaxVersion="0" modifyTime="2019-11-22T17:14:33Z">
+       <label>Settings ⇨ Security ⇨ Web Security ⇨ Allow Roaming Source Network Address</label>
+       <value>{{ pwm_allow_roaming }}</value>
+    </setting>
     <setting key="captcha.recaptcha.publicKey" syntax="STRING" syntaxVersion="0" modifyTime="2019-12-05T19:59:16Z">
       <label>Settings ⇨ Captcha ⇨ reCAPTCHA Site Key</label>
       <value>{{ pwm_captcha_recaptcha_publickey }}</value>


### PR DESCRIPTION
Variable handling to Allow Roaming Source Network Address (allow PWM to access a single HTTP session from different source IP addresses)